### PR TITLE
Make "under 5 issues" error clearer.

### DIFF
--- a/src/pages/New.tsx
+++ b/src/pages/New.tsx
@@ -126,7 +126,7 @@ const New = () => {
       setError("Repository is archived");
       return;
     } else if (data.open_issues <= 5) {
-      setError("Repository has under 5 issues");
+      setError("Repository should have at least 5 issues so it is ready for contributions.");
       return;
     } else {
       await projectRef.set(repoData);


### PR DESCRIPTION
It was hard to understand how it was an error because normally people would think "Under 5 issues? Issues are bad so that's a good thing, right?"

Now it has the message: "Repository should have at least 5 issues so it is ready for contributions." so people understand why it's an error.

As per https://twitter.com/IshanTheIshan/status/1377608957976584193 (I'm Ishan)
